### PR TITLE
Install and export library targets.

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -63,3 +63,39 @@ if("${PCRECPP_FOUND}")
     target_link_libraries(fileseq_shared ${PCRECPP_LIBRARIES})
     target_link_libraries(fileseq_static ${PCRECPP_LIBRARIES})
 endif()
+
+# For providing standard install location vars.
+include(GNUInstallDirs)
+
+# Install public headers.
+file(GLOB PUBLIC_HEADERS *.h)
+install(
+    FILES ${PUBLIC_HEADERS}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fileseq
+)
+
+# Install libraries.
+install(
+    TARGETS fileseq_shared fileseq_static
+    DESTINATION
+    EXPORT ${CMAKE_PROJECT_NAME}-targets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+# Produce a target import script for ease of importing into other CMake projects.
+install(
+    EXPORT ${CMAKE_PROJECT_NAME}-targets
+    FILE ${CMAKE_PROJECT_NAME}Targets.cmake
+    NAMESPACE ${CMAKE_PROJECT_NAME}::
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/cmake
+)
+
+# Configure & install <Project>Config.cmake (which includes fileseqTargets.cmake)
+set(OUTPUT_CONFIG ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}Config.cmake)
+configure_file(cmake/Config.cmake.in ${OUTPUT_CONFIG} @ONLY)
+install(
+    FILES ${OUTPUT_CONFIG}
+    DESTINATION ${CMAKE_INSTALL_PREFIX}
+)

--- a/cpp/cmake/Config.cmake.in
+++ b/cpp/cmake/Config.cmake.in
@@ -1,0 +1,6 @@
+get_filename_component(@CMAKE_PROJECT_NAME@_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+# Include the targets if the shared library target is not defined.
+if(NOT TARGET @CMAKE_PROJECT_NAME@::@CMAKE_PROJECT_NAME@_shared)
+    include("${@CMAKE_PROJECT_NAME@_CMAKE_DIR}/cmake/@CMAKE_PROJECT_NAME@Targets.cmake")
+endif()


### PR DESCRIPTION
- Install library targets and public headers
- Install fileseqConfig.cmake and fileseqTargets.cmake for importing
fileseq targets in consuming projects.

Signed-off-by: rlei-weta <rlei@wetafx.co.nz>